### PR TITLE
Proceed an goimports error

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ so if this is a heavily used template,  avoid it. Usually you will not notice a 
 and the third option can be very convenient. This third option is simply any go variable surrounded by mustaches 
 with no spaces.
 
+The i, u, and f tags use the strconv package, so be sure to include that in your template.
+
 #### Escaping Dynamic Text
 
 Some value types potentially could produce html reserved characters. The following tags will html escape

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,7 @@ github.com/goradd/gofile v0.1.2 h1:KGAMlp7zR5ARzkNqF9kK/mLPJK+s9xhpG2yFk7UxV+A=
 github.com/goradd/gofile v0.1.2/go.mod h1:Il/+n/haoU0ZJJjwJ6t9f+fFtxrUuEfCG/vEkV1n9is=
 github.com/goradd/gofile v0.1.6 h1:E6rGb3N2Lpp5Zr17FcUnchM0f6kAmvV0glcFJ+KpRSY=
 github.com/goradd/gofile v0.1.6/go.mod h1:FZVfQmXDUNgS7nKPMOsuIxf1VaC1vxYFeP0bmL8fcDU=
+github.com/goradd/gofile v0.1.9 h1:1XI9vf+gnbqrhjDHzyEogbcFStLeOEdlmXPdNXh1YRM=
 github.com/goradd/gofile v0.1.9/go.mod h1:1Dj3SdiqzATQ7s9QEhprIenY4sjktSAye7YtXDOHaVc=
 github.com/inconshreveable/mousetrap v1.0.0/go.mod h1:PxqpIevigyE2G7u3NXJIT2ANytuPF1OarO4DADm73n8=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=

--- a/main.go
+++ b/main.go
@@ -195,22 +195,23 @@ func postProcess(file string, runImports bool) {
 	if runImports {
 		_,err := sys.ExecuteShellCommand("goimports -w " + filepath.Base(file))
 		if err != nil {
-			if _,ok := err.(*exec.ExitError); ok {
-				panic("error running goimports on file " + file + ": " + string(err.(*exec.ExitError).Stderr))	// perhaps goimports is not installed?
-			} else {
-				panic(err)
+			if e,ok := err.(*exec.Error); ok {
+				panic("error running goimports on file " + file + ": " + e.Error())	// perhaps goimports is not installed?
+			} else if e,ok := err.(*exec.ExitError); ok {
+				// Likely a syntax error in the resulting file
+				log.Print(e.Stderr)
 			}
 		}
 	} else {
 		_,err :=  sys.ExecuteShellCommand("go fmt " + file) // at least format it if we are not going to run imports on it
 		if err != nil {
-			if _,ok := err.(*exec.ExitError); ok {
-				panic("error running fmt on file " + file + ": " + string(err.(*exec.ExitError).Stderr))
-			} else {
-				panic(err)
+			if e,ok := err.(*exec.Error); ok {
+				panic("error running goimports on file " + file + ": " + e.Error())	// perhaps goimports is not installed?
+			} else if e,ok := err.(*exec.ExitError); ok {
+				// Likely a syntax error in the resulting file
+				log.Print(e.Stderr)
 			}
 		}
-
 	}
 	_ = os.Chdir(curDir)
 }


### PR DESCRIPTION
Allowing got to produce output even when goimports fails with a syntax error.