### PR TITLE
Fixing problem with html include files

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,12 @@
 language: go
 
 go:
-  - "1.11.x"
-  - "1.12.x"
-  - "1.13.x"
+  - "1.14.x"
+  - "1.15.x"
 
 script:
-  - env GO111MODULE=on go install
-  - env GO111MODULE=on go test -v
+  - go install
+  - go test -v
 
 install:
   - go get golang.org/x/tools/cmd/goimports

--- a/README.md
+++ b/README.md
@@ -317,9 +317,14 @@ func OutTemplate(toPrint string, buf bytes.Buffer) error {
 Example: `{{: "myTemplate.inc" }}`
 
 #### Include a text file
-    {{:h "fileName" }} or {{includeEscaped "fileName" }}   Inserts the given file name into the template and html escapes it.
 
-Use this to include a text file that you want to reproduce in html.
+    {{:! "fileName" }} or {{includeEscaped "fileName" }}   Inserts the given file name into the template and html escapes it.
+    {{:h "fileName" }} or {{includeAsHtml "fileName" }}   Inserts the given file name into the template, html escapes it, and converts newlines into html breaks.
+
+Use `{{:!` to include a file that you surround with a `<pre>` tag to include a text file
+and have it appear in an html document looking the same. Use `{{:h` to include a file
+without the `<pre>` tags, but if the file uses extra spaces for indent, those spaces will
+not indent in the html.
  
 ### Defined Fragments
 

--- a/go.mod
+++ b/go.mod
@@ -8,4 +8,4 @@ require (
 	golang.org/x/tools v0.0.0-20190111181022-4b7be70d8ad9
 )
 
-go 1.13
+go 1.15

--- a/got/lexer.go
+++ b/got/lexer.go
@@ -178,7 +178,7 @@ func (l *lexer) lexTag(priorState stateFn) stateFn {
 		return l.lexStrictBlock(priorState, newline)
 
 	case itemInclude:
-		return l.lexInclude(priorState, i.htmlBreaks)
+		return l.lexInclude(priorState, i.htmlBreaks, i.escaped)
 
 	case itemNamedBlock:
 		return l.lexNamedBlock(priorState)
@@ -249,7 +249,7 @@ func (l *lexer) lexStrictBlock(nextState stateFn, newline bool) stateFn {
 	return nextState
 }
 
-func (l *lexer) lexInclude(nextState stateFn, convert bool) stateFn {
+func (l *lexer) lexInclude(nextState stateFn, htmlBreaks bool, escaped bool) stateFn {
 	l.ignore()
 	l.acceptRun()
 	fileName := strings.TrimSpace(l.currentString())
@@ -313,11 +313,11 @@ func (l *lexer) lexInclude(nextState stateFn, convert bool) stateFn {
 
 	s := string(buf[:])
 
-	if convert {
+	if htmlBreaks || escaped {
 		// treat file like a text file
 		l.ignore()
 		l.emitType(itemConvert)
-		l.emit(item{typ:itemRun, val: s})
+		l.emit(item{typ:itemRun, val: s, htmlBreaks: htmlBreaks, escaped: escaped})
 		l.emitType(itemEnd)
 
 		return nextState

--- a/got/token.go
+++ b/got/token.go
@@ -144,7 +144,9 @@ func init() {
 	tokens["{{:"] = item{typ: itemInclude}       // must follow with a file name
 	tokens["{{include"] = item{typ: itemInclude} // must follow with a file name
 	tokens["{{:h"] = item{typ: itemInclude, escaped:true, withError: false, htmlBreaks:true}       // must follow with a file name
-	tokens["{{includeEscaped"] = item{typ: itemInclude, escaped:true, withError: false, htmlBreaks:true} // must follow with a file name
+	tokens["{{includeAsHtml"] = item{typ: itemInclude, escaped:true, withError: false, htmlBreaks:true} // must follow with a file name
+	tokens["{{:!"] = item{typ: itemInclude, escaped:true, withError: false, htmlBreaks:false}       // must follow with a file name
+	tokens["{{includeEscaped"] = item{typ: itemInclude, escaped:true, withError: false, htmlBreaks:false} // must follow with a file name
 
 
 	tokens["{{-"] = item{typ: itemBackup}      // Can be followed by a number to indicate how many chars to backup

--- a/test/expected/TestInclude.out
+++ b/test/expected/TestInclude.out
@@ -4,21 +4,31 @@ The end.
 	Escaped html &lt;
 	</p>
 
-<p>This is text
+This is text
 that is both escaped and has
 html paragraphs and breaks inserted.
-</p>
 
 
 right
 
-<html>
-<head>
+&lt;html&gt;
+&lt;head&gt;
 
-</head>
-<body>
-<p>
+&lt;/head&gt;
+&lt;body&gt;
+&lt;p&gt;
     A typical html document
-</p>
-</body>
-</html>
+&lt;/p&gt;
+&lt;/body&gt;
+&lt;/html&gt;
+
+<p>&lt;html&gt;<br>
+&lt;head&gt;</p>
+<p>&lt;/head&gt;<br>
+&lt;body&gt;<br>
+&lt;p&gt;<br>
+    A typical html document<br>
+&lt;/p&gt;<br>
+&lt;/body&gt;<br>
+&lt;/html&gt;</p>
+

--- a/test/expected/TestStatic.out
+++ b/test/expected/TestStatic.out
@@ -3,9 +3,9 @@ Testing quotes: "'`
 <p>
 Escaped html &lt;
 </p>
-<p>This is text that
-	is escaped.</p>
-<p>	And has html paragraphs inserted.
-</p>
+This is text that
+	is escaped.
+
+	And has html paragraphs inserted.
 
 This should be testStatic: testStatic

--- a/test/src/testInclude.tpl.got
+++ b/test/src/testInclude.tpl.got
@@ -25,7 +25,12 @@ The end.
 
 {{
 {{# Including an html file in text mode }}
-{{: "testInclude3.html" }}
+{{:! "testInclude3.html" }}
+}}
+
+{{
+{{# Including an html file in html mode }}
+{{:h "testInclude3.html" }}
 }}
 
 


### PR DESCRIPTION
Adding option to include with escaped text, but without html newlines
Bumping go test version to 1.14 and 1.15